### PR TITLE
Add Electron + Python modular utility skeleton

### DIFF
--- a/sqx-util/.gitignore
+++ b/sqx-util/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.DS_Store
+*.pyc
+__pycache__/

--- a/sqx-util/README.md
+++ b/sqx-util/README.md
@@ -1,0 +1,28 @@
+# SQX Utility
+
+Utilitario de escritorio basado en Electron y Python.
+
+## Requisitos
+- [Node.js](https://nodejs.org/) instalado
+- [Python 3](https://www.python.org/) disponible en la ruta (`python --version`)
+
+## Instalación
+```bash
+npm install
+```
+
+## Ejecutar en modo desarrollo
+```bash
+npm run dev
+```
+
+## Añadir nuevos módulos Python
+1. Crear `backend/modules/<nuevo_modulo>.py` con una función `run(payload: dict) -> dict`.
+2. Desde la UI, llamar a:
+```javascript
+window.api.runModule('<nuevo_modulo>', { /* payload */ })
+```
+3. Añade un nuevo botón en `electron/renderer/app.js` para invocar el módulo.
+
+## Notas
+Este es un MVP que incluye el módulo `create_sqx_building_blocks` como ejemplo.

--- a/sqx-util/backend/modules/__init__.py
+++ b/sqx-util/backend/modules/__init__.py
@@ -1,0 +1,1 @@
+# Paquete de módulos. Agrega nuevos módulos aquí en el futuro.

--- a/sqx-util/backend/modules/create_sqx_building_blocks.py
+++ b/sqx-util/backend/modules/create_sqx_building_blocks.py
@@ -1,0 +1,6 @@
+def run(payload: dict) -> dict:
+    return {
+        "module": "Create SQX Building Blocks",
+        "message": "hola mundo",
+        "received_payload": payload
+    }

--- a/sqx-util/backend/requirements.txt
+++ b/sqx-util/backend/requirements.txt
@@ -1,0 +1,1 @@
+# No dependencies required for MVP

--- a/sqx-util/backend/run_module.py
+++ b/sqx-util/backend/run_module.py
@@ -1,0 +1,48 @@
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(BASE_DIR))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run backend module")
+    parser.add_argument('--module', required=True, help='Module name')
+    parser.add_argument('--payload', default='{}', help='JSON payload')
+    args = parser.parse_args()
+
+    module_name = args.module
+    if not module_name.isidentifier():
+        print(json.dumps({"error": "Invalid module name"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        module = importlib.import_module(f'modules.{module_name}')
+    except Exception as e:
+        print(json.dumps({"error": f"Cannot import module '{module_name}': {e}"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        payload = json.loads(args.payload) if args.payload else {}
+    except Exception as e:
+        print(json.dumps({"error": f"Invalid JSON payload: {e}"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = module.run(payload)
+        print(json.dumps(result))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)

--- a/sqx-util/electron/main.js
+++ b/sqx-util/electron/main.js
@@ -1,0 +1,42 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { runPythonModule } from '../scripts/python-runner.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 700,
+    title: 'SQX Utility',
+    center: true,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('run-module', async (event, { moduleName, payload }) => {
+  if (typeof moduleName !== 'string' || !/^[a-zA-Z0-9_]+$/.test(moduleName)) {
+    throw new Error('Invalid module name');
+  }
+  return runPythonModule(moduleName, payload);
+});

--- a/sqx-util/electron/preload.js
+++ b/sqx-util/electron/preload.js
@@ -1,0 +1,5 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {
+  runModule: (moduleName, payload) => ipcRenderer.invoke('run-module', { moduleName, payload })
+});

--- a/sqx-util/electron/renderer/app.js
+++ b/sqx-util/electron/renderer/app.js
@@ -1,0 +1,17 @@
+// Para agregar nuevos módulos, crea un botón adicional y llama a window.api.runModule('nombre_modulo', payload)
+
+const button = document.getElementById('run-btn');
+const resultDiv = document.getElementById('result');
+
+button.addEventListener('click', async () => {
+  button.disabled = true;
+  resultDiv.textContent = 'Ejecutando...';
+  try {
+    const response = await window.api.runModule('create_sqx_building_blocks', { example: true });
+    resultDiv.textContent = JSON.stringify(response, null, 2);
+  } catch (err) {
+    resultDiv.textContent = `Error: ${err.message}`;
+  } finally {
+    button.disabled = false;
+  }
+});

--- a/sqx-util/electron/renderer/index.html
+++ b/sqx-util/electron/renderer/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>SQX Utility</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>SQX Utility</h1>
+    <p class="subtitle">Utilidad modular</p>
+  </header>
+  <main>
+    <div class="card">
+      <h2>Create SQX Building Blocks</h2>
+      <p>Ejemplo de módulo que responde "hola mundo".</p>
+      <button id="run-btn">Run Create SQX Building Blocks</button>
+      <div id="result"></div>
+    </div>
+  </main>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/sqx-util/electron/renderer/styles.css
+++ b/sqx-util/electron/renderer/styles.css
@@ -1,0 +1,55 @@
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #f5f5f5;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.subtitle {
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  text-align: center;
+}
+
+button {
+  padding: 1rem 2rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+button:hover {
+  background: #0056b3;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+#result {
+  margin-top: 1rem;
+  white-space: pre-wrap;
+  text-align: left;
+  font-family: monospace;
+}

--- a/sqx-util/package.json
+++ b/sqx-util/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sqx-util",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "electron .",
+    "postinstall": ""
+  },
+  "devDependencies": {
+    "electron": "^28.0.0"
+  }
+}

--- a/sqx-util/scripts/python-runner.js
+++ b/sqx-util/scripts/python-runner.js
@@ -1,0 +1,46 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export function runPythonModule(moduleName, payload = {}) {
+  return new Promise((resolve, reject) => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const scriptPath = path.join(__dirname, '..', 'backend', 'run_module.py');
+    const args = [scriptPath, '--module', moduleName, '--payload', JSON.stringify(payload)];
+
+    const py = spawn('python', args);
+
+    let stdout = '';
+    let stderr = '';
+
+    py.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    py.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    py.on('error', (err) => {
+      reject(new Error(`Failed to start Python process: ${err.message}`));
+    });
+
+    py.on('close', (code) => {
+      if (code !== 0) {
+        try {
+          const errObj = JSON.parse(stderr);
+          reject(new Error(errObj.error || `Python exited with code ${code}`));
+        } catch (e) {
+          reject(new Error(stderr || `Python exited with code ${code}`));
+        }
+        return;
+      }
+      try {
+        const result = JSON.parse(stdout);
+        resolve(result);
+      } catch (e) {
+        reject(new Error('Invalid JSON output from Python'));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Electron 28 app with secure preload and renderer
- add Python backend with modular runner and example module
- provide JS bridge to spawn Python modules and display results

## Testing
- `node --check sqx-util/electron/main.js sqx-util/electron/preload.js sqx-util/electron/renderer/app.js sqx-util/scripts/python-runner.js`
- `python -m py_compile sqx-util/backend/run_module.py sqx-util/backend/modules/create_sqx_building_blocks.py`
- `node --input-type=module -e "import('./sqx-util/scripts/python-runner.js').then(({runPythonModule})=>runPythonModule('create_sqx_building_blocks',{example:true}).then(r=>console.log(r)).catch(e=>console.error(e)))"`


------
https://chatgpt.com/codex/tasks/task_b_689a9c2386c0832991dbb4cdf1eca34f